### PR TITLE
Split `myratings` message

### DIFF
--- a/cogs/ratings.py
+++ b/cogs/ratings.py
@@ -204,10 +204,22 @@ class Ratings(Cog):
         if len(result) == 0:
             await ctx.author.send("You have not rated any problems!")
         else:
-            ratings = "\n".join([f"{i[0]:<6}{i[1]}" for i in result])
-            await ctx.author.send(
-                f"Your ratings: ```Potd  Rating\n{ratings}```You have rated {len(result)} potds. "
-            )
+            ratings = [f"{i[0]:<6}{i[1]}" for i in result]
+
+            # Ensure that sent messages do not exceed character length
+            rating_msgs = []
+            rating_msg = []
+            for rating in ratings:
+                rating_msg.append(rating)
+                if sum([len(rating_str) + 1 for rating_str in rating_msg]) >= 1900:
+                    rating_msgs.append("\n".join(rating_msg))
+                    rating_msg = []
+            if len(rating_msg) != 0:
+                rating_msgs.append("\n".join(rating_msg))
+            await ctx.author.send("Your ratings:")
+            for msg in rating_msgs:
+                await ctx.author.send(f"```Potd  Rating\n{msg}\n```")
+            await ctx.author.send(f"You have rated {len(result)} potds.")
 
     @commands.command(
         aliases=["rmrating", "unrate"], brief="Removes your rating for a potd. "


### PR DESCRIPTION
Instead of breaking if a user has more than ~300 rated POTDs, `myratings` now splits its output into multiple messages to stay under the 2000 character limit.